### PR TITLE
add option 'autoBlur'

### DIFF
--- a/plugins-ui.js
+++ b/plugins-ui.js
@@ -17,6 +17,9 @@ function PluginsUI(game, opts) {
 
   opts = opts || {};
 
+  // option to blur self after input, to relinquish keyboard focus to game
+  this.autoBlur = opts.autoBlur || false
+
   this.gui = opts.gui || (game.plugins && game.plugins.get('voxel-debug') ? game.plugins.get('voxel-debug').gui : new createDatgui.GUI());
   this.folder = this.gui.addFolder('plugins');
 
@@ -61,5 +64,13 @@ function setStateForPlugin(self, name) {
       self.plugins.enable(name);
     else
       self.plugins.disable(name);
+
+    // if autoBlur is set, and gui has keyboard focus, blur self
+    if (self.autoBlur && document){
+      if (self.gui.domElement.contains(document.activeElement)) {
+        document.activeElement.blur()
+      }
+    }
+
   };
 }

--- a/plugins-ui.js
+++ b/plugins-ui.js
@@ -19,8 +19,9 @@ function PluginsUI(game, opts) {
 
   // option to blur self after input, to relinquish keyboard focus to game
   this.autoBlur = opts.autoBlur || false
-
-  this.gui = opts.gui || (game.plugins && game.plugins.get('voxel-debug') ? game.plugins.get('voxel-debug').gui : new createDatgui.GUI());
+  
+  var guiOpts = opts.guiOpts || {}
+  this.gui = opts.gui || (game.plugins && game.plugins.get('voxel-debug') ? game.plugins.get('voxel-debug').gui : new createDatgui.GUI(guiOpts));
   this.folder = this.gui.addFolder('plugins');
 
   this.pluginState = {};

--- a/plugins-ui.js
+++ b/plugins-ui.js
@@ -54,6 +54,7 @@ function PluginsUI(game, opts) {
 // add plugin checkbox widget
 PluginsUI.prototype.addPlugin = function (name) {
   this.pluginState[name] = this.plugins.isEnabled(name);
+  if (name in this.pluginItems) { return }
   this.pluginItems[name] = this.folder.add(this.pluginState, name);
   this.pluginItems[name].onChange(setStateForPlugin(this, name));
 };


### PR DESCRIPTION
This fixes an issue I had (on Mac Chrome 39) where the UI inputs grab keyboard focus and keep it even when the user clicks on the game screen (due to pointer lock I suppose?). Default is false, so this should not affect existing projects.

Having fun playing with the ndarray branch, cheers!
